### PR TITLE
Support double proxying by injecting headers from first proxy to second

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # A dynamic configurable reverse proxy for use within Galaxy
 
+To double-proxy (e.g. from Galaxy to a remote proxy that proxies to the application):
+
+```console
+host1$ ./lib/main.js --sessions test.sqlite --forwardIP host2 --forwardPort 8001
+host2$ ./lib/main.js --port 8001
+```

--- a/lib/main.js
+++ b/lib/main.js
@@ -13,7 +13,9 @@ args
     .option('--ip <n>', 'Public-facing IP of the proxy', 'localhost')
     .option('--port <n>', 'Public-facing port of the proxy', parseInt)
     .option('--sessions <file>', 'Routes file to monitor')
-    .option('--cookie <str>', 'IGNORED')
+    .option('--forwardIP <n>', 'Forward all requests to IP')
+    .option('--forwardPort <n>', 'Forward all requests to port', parseInt)
+    .option('--reverseProxy', 'Cause the proxy to rewrite location blocks with its own port')
     .option('--verbose')
 
 args.parse(process.argv);
@@ -21,7 +23,10 @@ args.parse(process.argv);
 var DynamicProxy = require('./proxy.js').DynamicProxy;
 var mapFor = require('./mapper.js').mapFor;
 
-var sessions = mapFor(args.sessions);
+var sessions = null;
+if(args.sessions) {
+    sessions = mapFor(args.sessions);
+}
 
 var dynamic_proxy_options = {
   sessionMap: sessions,
@@ -29,9 +34,17 @@ var dynamic_proxy_options = {
   port: args['port']
 }
 
-//if(args.reverseProxy){
- //   dynamic_proxy_options.reverseProxy = true;
-//}
+if(args.reverseProxy){
+    dynamic_proxy_options.reverseProxy = true;
+}
+
+if(args.forwardIP){
+    dynamic_proxy_options.forwardIP = args['forwardIP']
+}
+
+if(args.forwardPort){
+    dynamic_proxy_options.forwardPort = args['forwardPort']
+}
 
 var dynamic_proxy = new DynamicProxy(dynamic_proxy_options);
 

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -16,6 +16,8 @@ var DynamicProxy = function(options) {
     this.debug = options.verbose;
     this.reverseProxy = options.reverseProxy;
     this.port = options.port;
+    this.forwardIP = options.forwardIP;
+    this.forwardPort = options.forwardPort;
 
     var log_errors = function(handler) {
         return function (req, res) {
@@ -57,25 +59,58 @@ DynamicProxy.prototype.rewriteRequest = function(request) {
     }
 }
 
+DynamicProxy.prototype.targetFromSessionMap = function(request) {
+    for (var mappedSession in this.sessionMap) {
+        if(key == mappedSession) {
+            if(this.sessionMap[key].token == token){
+                return this.sessionMap[key].target;
+            }
+        }
+    }
+}
+
+DynamicProxy.prototype.targetFromHeaders = function(request) {
+    return {'host': request.headers['x-interactive-tool-host'], 'port': parseInt(request.headers['x-interactive-tool-port'])};
+}
+
 DynamicProxy.prototype.targetForRequest = function(request) {
     // return proxy target for a given url
     req_host = request.headers.host;
     key = req_host.substring(0, req_host.indexOf('-'));
     token = req_host.substring(req_host.indexOf('-') + 1, req_host.indexOf('.'));
 
-    for (var mappedSession in this.sessionMap) {
-        if(key == mappedSession) {
-		if(this.sessionMap[key].token == token){
-            		return this.sessionMap[key].target;
-		}
-        }
+    if(this.sessionMap) {
+        var target = this.targetFromSessionMap(request);
+    } else {
+        var target = this.targetFromHeaders(request);
+    }
+
+    if(target) {
+        return target;
     }
 
     if(this.debug) {
-        console.log("No target found for " + req_host + " " + req.method + " " + req.url)
+        console.log("No target found for " + req_host + " " + request.method + " " + request.url)
     }
     return null;
 };
+
+
+DynamicProxy.prototype.configureForward = function(req, target) {
+    var _target = Object.assign({}, target);
+    // FIXME: else delete header so the proxy can't be controlled
+    if(this.forwardIP) {
+        console.log("Forwarding request for " + target.host + " to " + this.forwardIP);
+        req.headers['x-interactive-tool-host'] = target.host;
+        _target.host = this.forwardIP;
+    }
+    if(this.forwardPort) {
+        console.log("Forwarding request for " + target.port + " to " + this.forwardPort);
+        req.headers['x-interactive-tool-port'] = target.port;
+        _target.port = this.forwardPort;
+    }
+    return _target
+}
 
 DynamicProxy.prototype.handleProxyRequest = function(req, res) {
     var othis = this;
@@ -118,6 +153,7 @@ DynamicProxy.prototype.handleProxyRequest = function(req, res) {
         }
 
     }
+    target = this.configureForward(req, target);
     this.proxy.web(req, res, {
         target: target
     }, function (e) {

--- a/lib/proxy.js
+++ b/lib/proxy.js
@@ -98,16 +98,19 @@ DynamicProxy.prototype.targetForRequest = function(request) {
 
 DynamicProxy.prototype.configureForward = function(req, target) {
     var _target = Object.assign({}, target);
-    // FIXME: else delete header so the proxy can't be controlled
     if(this.forwardIP) {
         console.log("Forwarding request for " + target.host + " to " + this.forwardIP);
         req.headers['x-interactive-tool-host'] = target.host;
         _target.host = this.forwardIP;
+    } else {
+        delete req.headers['x-interactive-tool-host'];
     }
     if(this.forwardPort) {
         console.log("Forwarding request for " + target.port + " to " + this.forwardPort);
         req.headers['x-interactive-tool-port'] = target.port;
         _target.port = this.forwardPort;
+    } else {
+        delete req.headers['x-interactive-tool-port'];
     }
     return _target
 }


### PR DESCRIPTION
Creating this mainly for @jmchilton who is going to pick it up.

For some scenarios (e.g. kubernetes, or clusters without a public IP), you need to run the proxy on some gateway host that has access to the nodes but not the session map database. To support such scenarios, it's (surprisingly) possible to double proxy: The first proxy runs on the Galaxy server and injects headers containing the node IP/port into the request to the second proxy, which runs on the gateway node.

This has *very* minimal security: clients can't pass the headers to the first proxy to control the second, but if they have direct access to the second, they can pass it headers and control it. This should be fine if you're running on a secured network and your second proxy isn't accessible from hosts other than the Galaxy server (which could be enforced with e.g. iptables). But for wider area deployments we ought to add the ability (much like Pulsar has) to require a shared key on the second proxy that is passed via an additional header from the first, and recommend the second proxy to run behind nginx w/ SSL, e.g.:

```
client
-> nginx:443@gxserver
-> proxy:8888@gxserver
-> nginx:8443@gateway
-> proxy:8888@gateway
-> ingress:random@k8s
-> container:app@node
```

I have tested this locally with a Jupyter notebook in docker and both proxies running on a single host, hopefully it works IRL.